### PR TITLE
Initialize return variable in iframe widget

### DIFF
--- a/hearthisat/hearthis-shortcode.php
+++ b/hearthisat/hearthis-shortcode.php
@@ -348,12 +348,13 @@ include(__DIR__.'/httpful.phar');
 
     if(isset($return['SL']))
     {
-      for ($i=0; $i < count($return['SL']); $i++) 
-      { 
+      $_return = '';
+      for ($i=0; $i < count($return['SL']); $i++)
+      {
         $_return .= $return['SL'][$i];
       }
       return $_return;
-    } 
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- initialize `$_return` before looping through player snippets

## Testing
- `php -l hearthisat/hearthis-shortcode.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840325ad624832a922de53d00ca6cde