### PR TITLE
Fix option retrieval and initialization

### DIFF
--- a/hearthisat/hearthis-shortcode.php
+++ b/hearthisat/hearthis-shortcode.php
@@ -60,11 +60,11 @@ include(__DIR__.'/httpful.phar');
     $shortcode_options['params'] = $shortcode_params;
 
     if(hearthis_url_is_type($shortcode_options['url']) === 'set')
-      $height = get_option('player_height',450);
-    else if (hearthis_url_is_type($shortcode_options['url']) === 'profile') 
-      $height = get_option('player_height',350);
-    else if (hearthis_url_is_type($shortcode_options['url']) === 'track') 
-      $height = get_option('player_height',145);
+      $height = get_option('hearthis_player_height_multi', 450);
+    else if (hearthis_url_is_type($shortcode_options['url']) === 'profile')
+      $height = get_option('hearthis_player_profile_height', 350);
+    else if (hearthis_url_is_type($shortcode_options['url']) === 'track')
+      $height = get_option('hearthis_player_height', 145);
     // else
     //   $height = hearthis_get_option('player_height',145);
 
@@ -331,16 +331,16 @@ include(__DIR__.'/httpful.phar');
     $height = $options['height'];
     $return = array();
     
-  $infos = hearthis_bypass_set_url($options['url']);   
+  $infos = hearthis_bypass_set_url($options['url']);
   $url = hearthis_iframe_url($options,$infos);
 
     if(isset($options['liststyle']) && $options['liststyle'] === 'single')
-    { 
-         foreach($url as $href) 
+    {
+         foreach($url as $href)
          {
               $return['SL'][] = sprintf('<div><iframe class="hearthis-iframe-widget" width="%s" height="%s" scrolling="no" frameborder="no" src="%s" allowtransparency></iframe></div>', $width, '145', $href);
          }
-    } 
+    }
     else {
         $return['SL'][] = sprintf('<iframe class="hearthis-iframe-widget" width="%s" height="%s" scrolling="no" frameborder="no" src="%s" allowtransparency></iframe>', $width, $height, $url);
     }
@@ -348,8 +348,9 @@ include(__DIR__.'/httpful.phar');
 
     if(isset($return['SL']))
     {
-      for ($i=0; $i < count($return['SL']); $i++) 
-      { 
+      $_return = '';
+      for ($i=0; $i < count($return['SL']); $i++)
+      {
         $_return .= $return['SL'][$i];
       }
       return $_return;


### PR DESCRIPTION
## Summary
- use correct option names when determining default player height
- initialize return string in iframe rendering

## Testing
- `php -l hearthisat/hearthis-shortcode.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684031c619f8832abfe1f73c31b0c908